### PR TITLE
[Draft] Adds composite run configs to run multiple instances of the game

### DIFF
--- a/Demo.gd
+++ b/Demo.gd
@@ -1,0 +1,8 @@
+extends Node
+
+func _ready():
+  self.print("MYVAR = " + OS.get_environment("MY_VAR"))
+
+func print(message: String):
+  var label = get_node("/root/Scene/Output")
+  label.text += "\n" + message

--- a/addons/run-configs/editor/controls/configs_editor/composite_editor.gd
+++ b/addons/run-configs/editor/controls/configs_editor/composite_editor.gd
@@ -1,0 +1,62 @@
+@tool
+extends Control
+class_name CompositeEdit
+
+const RunConfig := preload("res://addons/run-configs/models/run_config.gd")
+
+@onready var grid_container: GridContainer = $GridContainer
+@onready var add_item_btn: Button = $BtnContainer/AddConfig
+@onready var del_item_btn: Button = $BtnContainer/DelConfig
+
+signal changed(envs: Array[int])
+
+var _all_configs: Array[RunConfig]
+
+func _ready():
+	add_item_btn.pressed.connect(_add_item)
+	del_item_btn.pressed.connect(_del_item)
+
+func render(composite_configs: Array[StringName], all_configs: Array[RunConfig]):
+	del_item_btn.disabled = composite_configs.size() <= 0
+	_all_configs = all_configs
+
+	for child in grid_container.get_children():
+		child.queue_free()
+
+	for item in composite_configs:
+		var opt = create_option(item)
+
+func create_option(cur_name: StringName = "") -> OptionButton:
+	var option = OptionButton.new()
+
+	var index = 0
+	for c in _all_configs:
+		if c.play_mode != RunConfig.PlayMode.Composite:
+			option.add_item(c.name)
+		if index >= 0 and index < option.item_count and cur_name == option.get_item_text(index):
+			option.select(index)
+		index += 1
+
+	option.item_selected.connect(_on_item_selected)
+	grid_container.add_child(option)
+	return option
+
+func _emit_changes():
+	var new_configs: Array[StringName] = []
+	for child in grid_container.get_children():
+		new_configs.append(child.get_item_text(child.selected))
+	changed.emit(new_configs)
+
+func _add_item():
+	create_option()
+	_emit_changes()
+
+func _del_item():
+	var children = grid_container.get_children()
+	if children.size() <= 0: return 
+
+	children[children.size() - 1].queue_free()
+	_emit_changes()
+
+func _on_item_selected(id):
+	_emit_changes()

--- a/addons/run-configs/editor/controls/configs_editor/composite_editor.gd
+++ b/addons/run-configs/editor/controls/configs_editor/composite_editor.gd
@@ -16,7 +16,7 @@ func _ready():
 	add_item_btn.pressed.connect(_add_item)
 	del_item_btn.pressed.connect(_del_item)
 
-func render(composite_configs: Array[StringName], all_configs: Array[RunConfig]):
+func render(composite_configs: Array, all_configs: Array[RunConfig]):
 	del_item_btn.disabled = composite_configs.size() <= 0
 	_all_configs = all_configs
 

--- a/addons/run-configs/editor/controls/configs_editor/configs_editor.gd
+++ b/addons/run-configs/editor/controls/configs_editor/configs_editor.gd
@@ -45,7 +45,7 @@ func _ready():
 	custom_scene_edit.pressed.connect(func(): file_dialog.popup_centered_ratio())
 	file_dialog.file_selected.connect(func(file): _update_value(&"custom_scene", file))
 	env_edit.changed.connect(func(envs): _update_value(&"environment_variables", envs))
-	composite_edit.changed.connect(func(configs): _update_value(&"composite_configs", configs))
+	composite_edit.changed.connect(func(_configs): _update_value(&"composite_configs", _configs))
 
 	confirmed.connect(func(): ConfigsManager.set_configs(configs))
 
@@ -154,4 +154,3 @@ func _update_value(property: StringName, value):
 		
 	var config := configs[selected]
 	config.set(property, value)
-

--- a/addons/run-configs/editor/controls/configs_editor/configs_editor.tscn
+++ b/addons/run-configs/editor/controls/configs_editor/configs_editor.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/env_editor.gd" id="3_2bcxm"]
 [ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/composite_editor.gd" id="3_47qek"]
 
-[sub_resource type="Image" id="Image_11r8h"]
+[sub_resource type="Image" id="Image_g4umc"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -14,8 +14,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_pkwlf"]
-image = SubResource("Image_11r8h")
+[sub_resource type="ImageTexture" id="ImageTexture_g777a"]
+image = SubResource("Image_g4umc")
 
 [sub_resource type="GDScript" id="GDScript_knwq4"]
 script/source = "@tool
@@ -79,14 +79,14 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Add a new config"
-icon = SubResource("ImageTexture_pkwlf")
+icon = SubResource("ImageTexture_g777a")
 script = SubResource("GDScript_knwq4")
 
 [node name="RemoveConfig" type="Button" parent="MarginContainer/ConfigsEditor/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Remove selected config"
-icon = SubResource("ImageTexture_pkwlf")
+icon = SubResource("ImageTexture_g777a")
 script = SubResource("GDScript_b2o0p")
 
 [node name="HSplitContainer" type="HSplitContainer" parent="MarginContainer/ConfigsEditor"]
@@ -148,16 +148,16 @@ size_flags_horizontal = 3
 item_count = 4
 selected = 0
 popup/item_0/text = "Main Scene"
-popup/item_0/icon = SubResource("ImageTexture_pkwlf")
+popup/item_0/icon = SubResource("ImageTexture_g777a")
 popup/item_0/id = 0
 popup/item_1/text = "Current Scene"
-popup/item_1/icon = SubResource("ImageTexture_pkwlf")
+popup/item_1/icon = SubResource("ImageTexture_g777a")
 popup/item_1/id = 1
 popup/item_2/text = "Custom Scene"
-popup/item_2/icon = SubResource("ImageTexture_pkwlf")
+popup/item_2/icon = SubResource("ImageTexture_g777a")
 popup/item_2/id = 2
 popup/item_3/text = "Multiple Instances"
-popup/item_3/icon = SubResource("ImageTexture_pkwlf")
+popup/item_3/icon = SubResource("ImageTexture_g777a")
 popup/item_3/id = 3
 script = ExtResource("1_bhvuh")
 tooltips = Array[String](["", "", "", "Allows you to run multiple instances of the game, useful for multiplayer"])
@@ -168,7 +168,7 @@ visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Choose a scene..."
-icon = SubResource("ImageTexture_pkwlf")
+icon = SubResource("ImageTexture_g777a")
 script = SubResource("GDScript_fhb5p")
 
 [node name="CompositeLabel" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
@@ -199,7 +199,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 2
 text = "Add"
-icon = SubResource("ImageTexture_pkwlf")
+icon = SubResource("ImageTexture_g777a")
 script = SubResource("GDScript_ggysl")
 
 [node name="DelConfig" type="Button" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form/CompositeEdit/BtnContainer"]
@@ -207,7 +207,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 2
 text = "Remove"
-icon = SubResource("ImageTexture_pkwlf")
+icon = SubResource("ImageTexture_g777a")
 script = SubResource("GDScript_ggysl")
 
 [node name="Env" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
@@ -230,7 +230,7 @@ columns = 3
 layout_mode = 2
 size_flags_horizontal = 8
 text = "New Variable"
-icon = SubResource("ImageTexture_pkwlf")
+icon = SubResource("ImageTexture_g777a")
 script = SubResource("GDScript_ggysl")
 
 [node name="Hint" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer"]

--- a/addons/run-configs/editor/controls/configs_editor/configs_editor.tscn
+++ b/addons/run-configs/editor/controls/configs_editor/configs_editor.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/env_editor.gd" id="3_2bcxm"]
 [ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/composite_editor.gd" id="3_47qek"]
 
-[sub_resource type="Image" id="Image_g4umc"]
+[sub_resource type="Image" id="Image_4dn1c"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -14,8 +14,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_g777a"]
-image = SubResource("Image_g4umc")
+[sub_resource type="ImageTexture" id="ImageTexture_jvrdx"]
+image = SubResource("Image_4dn1c")
 
 [sub_resource type="GDScript" id="GDScript_knwq4"]
 script/source = "@tool
@@ -79,14 +79,14 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Add a new config"
-icon = SubResource("ImageTexture_g777a")
+icon = SubResource("ImageTexture_jvrdx")
 script = SubResource("GDScript_knwq4")
 
 [node name="RemoveConfig" type="Button" parent="MarginContainer/ConfigsEditor/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Remove selected config"
-icon = SubResource("ImageTexture_g777a")
+icon = SubResource("ImageTexture_jvrdx")
 script = SubResource("GDScript_b2o0p")
 
 [node name="HSplitContainer" type="HSplitContainer" parent="MarginContainer/ConfigsEditor"]
@@ -148,16 +148,16 @@ size_flags_horizontal = 3
 item_count = 4
 selected = 0
 popup/item_0/text = "Main Scene"
-popup/item_0/icon = SubResource("ImageTexture_g777a")
+popup/item_0/icon = SubResource("ImageTexture_jvrdx")
 popup/item_0/id = 0
 popup/item_1/text = "Current Scene"
-popup/item_1/icon = SubResource("ImageTexture_g777a")
+popup/item_1/icon = SubResource("ImageTexture_jvrdx")
 popup/item_1/id = 1
 popup/item_2/text = "Custom Scene"
-popup/item_2/icon = SubResource("ImageTexture_g777a")
+popup/item_2/icon = SubResource("ImageTexture_jvrdx")
 popup/item_2/id = 2
 popup/item_3/text = "Multiple Instances"
-popup/item_3/icon = SubResource("ImageTexture_g777a")
+popup/item_3/icon = SubResource("ImageTexture_jvrdx")
 popup/item_3/id = 3
 script = ExtResource("1_bhvuh")
 tooltips = Array[String](["", "", "", "Allows you to run multiple instances of the game, useful for multiplayer"])
@@ -168,7 +168,7 @@ visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Choose a scene..."
-icon = SubResource("ImageTexture_g777a")
+icon = SubResource("ImageTexture_jvrdx")
 script = SubResource("GDScript_fhb5p")
 
 [node name="CompositeLabel" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
@@ -199,7 +199,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 2
 text = "Add"
-icon = SubResource("ImageTexture_g777a")
+icon = SubResource("ImageTexture_jvrdx")
 script = SubResource("GDScript_ggysl")
 
 [node name="DelConfig" type="Button" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form/CompositeEdit/BtnContainer"]
@@ -207,7 +207,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 2
 text = "Remove"
-icon = SubResource("ImageTexture_g777a")
+icon = SubResource("ImageTexture_jvrdx")
 script = SubResource("GDScript_ggysl")
 
 [node name="Env" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
@@ -230,7 +230,7 @@ columns = 3
 layout_mode = 2
 size_flags_horizontal = 8
 text = "New Variable"
-icon = SubResource("ImageTexture_g777a")
+icon = SubResource("ImageTexture_jvrdx")
 script = SubResource("GDScript_ggysl")
 
 [node name="Hint" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer"]

--- a/addons/run-configs/editor/controls/configs_editor/configs_editor.tscn
+++ b/addons/run-configs/editor/controls/configs_editor/configs_editor.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=10 format=3 uid="uid://dso1w1uqfsxmi"]
+[gd_scene load_steps=11 format=3 uid="uid://dso1w1uqfsxmi"]
 
 [ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/play_mode_dropdown.gd" id="1_bhvuh"]
 [ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/configs_editor.gd" id="1_ldnip"]
 [ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/env_editor.gd" id="3_2bcxm"]
+[ext_resource type="Script" path="res://addons/run-configs/editor/controls/configs_editor/composite_editor.gd" id="3_47qek"]
 
-[sub_resource type="Image" id="Image_hwolb"]
+[sub_resource type="Image" id="Image_11r8h"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -13,8 +14,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_hfgpw"]
-image = SubResource("Image_hwolb")
+[sub_resource type="ImageTexture" id="ImageTexture_pkwlf"]
+image = SubResource("Image_11r8h")
 
 [sub_resource type="GDScript" id="GDScript_knwq4"]
 script/source = "@tool
@@ -51,7 +52,7 @@ func _ready() -> void:
 [node name="ConfigsEditor" type="ConfirmationDialog"]
 title = "Edit Run Configurations"
 initial_position = 2
-size = Vector2i(698, 400)
+size = Vector2i(897, 400)
 visible = true
 ok_button_text = "Apply"
 script = ExtResource("1_ldnip")
@@ -59,7 +60,7 @@ script = ExtResource("1_ldnip")
 [node name="MarginContainer" type="MarginContainer" parent="."]
 offset_left = 8.0
 offset_top = 8.0
-offset_right = 690.0
+offset_right = 889.0
 offset_bottom = 351.0
 theme_override_constants/margin_left = 8
 theme_override_constants/margin_top = 8
@@ -78,14 +79,14 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Add a new config"
-icon = SubResource("ImageTexture_hfgpw")
+icon = SubResource("ImageTexture_pkwlf")
 script = SubResource("GDScript_knwq4")
 
 [node name="RemoveConfig" type="Button" parent="MarginContainer/ConfigsEditor/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Remove selected config"
-icon = SubResource("ImageTexture_hfgpw")
+icon = SubResource("ImageTexture_pkwlf")
 script = SubResource("GDScript_b2o0p")
 
 [node name="HSplitContainer" type="HSplitContainer" parent="MarginContainer/ConfigsEditor"]
@@ -133,7 +134,8 @@ size_flags_horizontal = 3
 layout_mode = 2
 tooltip_text = "Scene that will be run
 This only applies if you run via the custom \"Run Config\" button"
-text = "Run Scene"
+text = "Play Mode
+"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
 layout_mode = 2
@@ -143,18 +145,22 @@ size_flags_horizontal = 3
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-item_count = 3
+item_count = 4
 selected = 0
 popup/item_0/text = "Main Scene"
-popup/item_0/icon = SubResource("ImageTexture_hfgpw")
+popup/item_0/icon = SubResource("ImageTexture_pkwlf")
 popup/item_0/id = 0
 popup/item_1/text = "Current Scene"
-popup/item_1/icon = SubResource("ImageTexture_hfgpw")
+popup/item_1/icon = SubResource("ImageTexture_pkwlf")
 popup/item_1/id = 1
 popup/item_2/text = "Custom Scene"
-popup/item_2/icon = SubResource("ImageTexture_hfgpw")
+popup/item_2/icon = SubResource("ImageTexture_pkwlf")
 popup/item_2/id = 2
+popup/item_3/text = "Multiple Instances"
+popup/item_3/icon = SubResource("ImageTexture_pkwlf")
+popup/item_3/id = 3
 script = ExtResource("1_bhvuh")
+tooltips = Array[String](["", "", "", "Allows you to run multiple instances of the game, useful for multiplayer"])
 
 [node name="CustomSceneEdit" type="Button" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form/HBoxContainer"]
 unique_name_in_owner = true
@@ -162,8 +168,47 @@ visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Choose a scene..."
-icon = SubResource("ImageTexture_hfgpw")
+icon = SubResource("ImageTexture_pkwlf")
 script = SubResource("GDScript_fhb5p")
+
+[node name="CompositeLabel" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 0
+tooltip_text = "Environment variables
+Use OS.get_environment() to access these values in runtime"
+text = "Configs To Run"
+
+[node name="CompositeEdit" type="VBoxContainer" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
+unique_name_in_owner = true
+layout_mode = 2
+script = ExtResource("3_47qek")
+
+[node name="GridContainer" type="GridContainer" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form/CompositeEdit"]
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 3
+size_flags_stretch_ratio = 6.22
+
+[node name="BtnContainer" type="HBoxContainer" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form/CompositeEdit"]
+layout_mode = 2
+alignment = 2
+
+[node name="AddConfig" type="Button" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form/CompositeEdit/BtnContainer"]
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 2
+text = "Add"
+icon = SubResource("ImageTexture_pkwlf")
+script = SubResource("GDScript_ggysl")
+
+[node name="DelConfig" type="Button" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form/CompositeEdit/BtnContainer"]
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 2
+text = "Remove"
+icon = SubResource("ImageTexture_pkwlf")
+script = SubResource("GDScript_ggysl")
 
 [node name="Env" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer/Form"]
 layout_mode = 2
@@ -185,7 +230,7 @@ columns = 3
 layout_mode = 2
 size_flags_horizontal = 8
 text = "New Variable"
-icon = SubResource("ImageTexture_hfgpw")
+icon = SubResource("ImageTexture_pkwlf")
 script = SubResource("GDScript_ggysl")
 
 [node name="Hint" type="Label" parent="MarginContainer/ConfigsEditor/HSplitContainer/ScrollContainer/PanelContainer"]

--- a/addons/run-configs/editor/controls/configs_editor/env_editor.gd
+++ b/addons/run-configs/editor/controls/configs_editor/env_editor.gd
@@ -12,7 +12,6 @@ func _ready() -> void:
 	add_env_button.pressed.connect(_add_column)
 	grid_container.resized.connect(_on_resize)
 
-
 func render(envs: Dictionary):
 	_delete_all_columns()
 	

--- a/addons/run-configs/editor/controls/configs_editor/play_mode_dropdown.gd
+++ b/addons/run-configs/editor/controls/configs_editor/play_mode_dropdown.gd
@@ -1,10 +1,18 @@
 @tool
 extends OptionButton
 
+@export var tooltips : Array[String]
+
 func _ready():
 	clear()
 	add_icon_item(get_theme_icon(&"Play", &"EditorIcons"), "Main Scene")
 	add_icon_item(get_theme_icon(&"PlayScene", &"EditorIcons"), "Current Scene")
 	add_icon_item(get_theme_icon(&"PlayCustom", &"EditorIcons"), "Custom Scene")
+	add_icon_item(get_theme_icon(&"Duplicate", &"EditorIcons"), "Multiple Instances")
+
+	item_selected.connect(_on_item_selected)
 
 	select(0)
+
+func _on_item_selected(idx: int):
+	tooltip_text = tooltips[idx]

--- a/addons/run-configs/editor/plugin.gd
+++ b/addons/run-configs/editor/plugin.gd
@@ -25,6 +25,7 @@ var inspector_plugin := InspectorPlugin.new()
 const AUTOLOAD_PATH = &"RunConfigManager"
 var confg_manager_autoload := ConfigManager.new()
 
+var _pids = []
 
 func _enter_tree():
 	var base_control := get_editor_interface().get_base_control()
@@ -33,7 +34,7 @@ func _enter_tree():
 	UIExtension.add_control_to_editor_run_bar(separator)
 	# - Play Button
 	play_button.icon = preload("res://addons/run-configs/editor/assets/PlayConfig.svg")
-	play_button.pressed.connect(_play_scene)
+	play_button.pressed.connect(_on_play_pressed)
 	play_button.tooltip_text = "Run Config Scene (Shift + F5)"
 	UIExtension.add_control_to_editor_run_bar(play_button)
 	# - Configs button
@@ -48,9 +49,11 @@ func _enter_tree():
 		editor_settings.set_setting(_RUN_SHORTCUT_PATH, RunShortcut.duplicate())
 	editor_settings.set_initial_value(_RUN_SHORTCUT_PATH, RunShortcut.duplicate(), false)
 
+func _exit_tree():
+	_kill_pids()
+
 func _enable_plugin() -> void:
 	add_autoload_singleton(AUTOLOAD_PATH, "res://addons/run-configs/run-config-manager.gd")
-
 
 func _disable_plugin() -> void:
 	UIExtension.remove_control_from_editor_run_bar(separator)
@@ -61,14 +64,19 @@ func _disable_plugin() -> void:
 	
 	remove_autoload_singleton(AUTOLOAD_PATH)
 	
-
-
-func _play_scene():
+func _on_play_pressed():
 	var config := ConfigManager.get_current_config()
 
 	if not config:
 		EditorInterface.play_main_scene()
 
+	if config.play_mode == RunConfig.PlayMode.Composite:
+		_run_composite_config(config)
+	else:
+		_play_in_editor(config)
+
+
+func _play_in_editor(config: RunConfig):
 	match config.play_mode:
 		RunConfig.PlayMode.MainScene:
 			EditorInterface.play_main_scene()
@@ -77,10 +85,39 @@ func _play_scene():
 		RunConfig.PlayMode.CustomScene:
 			var scene := config.custom_scene
 			EditorInterface.play_custom_scene(scene)
-		RunConfig.PlayMode.Composite:
+
+func _run_composite_config(config: RunConfig):
+	if config.play_mode != RunConfig.PlayMode.Composite:
+		return
+	if config.composite_configs.size() <= 0:
+		push_warning("Trying to run a composite config without having specified configs to run")
+		return
+	_kill_pids()
+
+	# Run all configs in separate processes except the first one
+	for i in range(1, config.composite_configs.size()):
+		var c = ConfigManager.get_config_from_name(config.composite_configs[i])
+		if c:
+			_play_as_separate_process(c)
+
+	# Run the first config of the list in editor for easy debugging
+	var c = ConfigManager.get_config_from_name(config.composite_configs[0])
+	if c:
+		_play_in_editor(c)
+
+func _play_as_separate_process(config: RunConfig):
+	var args = []
+	match config.play_mode:
+		RunConfig.PlayMode.MainScene:
 			pass
+		RunConfig.PlayMode.CurrentScene:
+			args.append(get_tree().edited_scene_root.scene_file_path)
+		RunConfig.PlayMode.CustomScene:
+			var scene := config.custom_scene
+			args.append(scene)
 
-
+	_pids.append(OS.create_process(OS.get_executable_path(), args))
+		
 
 func _input(event: InputEvent):
 	var editor_settings := EditorInterface.get_editor_settings()
@@ -93,4 +130,9 @@ func _input(event: InputEvent):
 		
 	if event is InputEventKey:
 		if shortcut.matches_event(event) and event.is_pressed() and not event.is_echo():
-			_play_scene()
+			_on_play_pressed()
+
+func _kill_pids():
+	for pid in _pids:
+		OS.kill(pid)
+	_pids = []

--- a/addons/run-configs/editor/plugin.gd
+++ b/addons/run-configs/editor/plugin.gd
@@ -77,6 +77,8 @@ func _play_scene():
 		RunConfig.PlayMode.CustomScene:
 			var scene := config.custom_scene
 			EditorInterface.play_custom_scene(scene)
+		RunConfig.PlayMode.Composite:
+			pass
 
 
 

--- a/addons/run-configs/models/run_config.gd
+++ b/addons/run-configs/models/run_config.gd
@@ -1,7 +1,7 @@
 @tool
 extends Resource
 
-enum PlayMode { MainScene, CurrentScene, CustomScene }
+enum PlayMode { MainScene, CurrentScene, CustomScene, Composite }
 
 @export_category("Run Config")
 
@@ -15,12 +15,17 @@ enum PlayMode { MainScene, CurrentScene, CustomScene }
 		play_mode = val
 		if play_mode != PlayMode.CustomScene:
 			custom_scene = ""
+		if play_mode != PlayMode.Composite:
+			composite_configs = []
 		notify_property_list_changed()
 ## Custom scene to launch
 @export_file("*.tscn", "*.scn") var custom_scene: String
 
 ## Environment variables
 @export var environment_variables: Dictionary
+
+## List of configs to run if this config is composite
+@export var composite_configs: Array[StringName] = []
 
 
 # Serialization
@@ -29,7 +34,8 @@ func serialize() -> String:
 		"name": name,
 		"play_mode": play_mode,
 		"custom_scene": custom_scene,
-		"environment_variables": environment_variables
+		"environment_variables": environment_variables,
+		"composite_configs": composite_configs
 	}
 	
 	return JSON.stringify(dict)
@@ -42,6 +48,11 @@ func deserialize(json: String) -> Resource:
 	play_mode = dict.play_mode
 	custom_scene = dict.custom_scene
 	environment_variables = dict.environment_variables
+
+	## dict.composite_configs is null if you already have configs savec
+	## on your computer, so we check in order to avoid problems when updating
+	if dict.get("composite_configs"):
+		composite_configs = dict.composite_configs
 	
 	return self
 

--- a/addons/run-configs/models/run_config.gd
+++ b/addons/run-configs/models/run_config.gd
@@ -25,7 +25,7 @@ enum PlayMode { MainScene, CurrentScene, CustomScene, Composite }
 @export var environment_variables: Dictionary
 
 ## List of configs to run if this config is composite
-@export var composite_configs: Array[StringName] = []
+@export var composite_configs: Array = []
 
 
 # Serialization

--- a/addons/run-configs/run-config-manager.gd
+++ b/addons/run-configs/run-config-manager.gd
@@ -8,6 +8,8 @@ const _CURRENT_CONFIG_PATH := CONFIGS_BASE_PATH + _CONFIGS_DATA_PATH + "/current
 
 const RunConfig := preload("res://addons/run-configs/models/run_config.gd")
 
+var pids = []
+
 func _init():
 	if not OS.has_feature(&"editor"):
 		return
@@ -32,6 +34,13 @@ func _ready():
 	if config.custom_scene != "" and get_tree().current_scene.scene_file_path != config.custom_scene:
 		print_rich("[color=gray][Run Config][/color] [color=yellow][Warn][/color] The [b]%s[/b] config has a custom scene set, but the game is ran from the regular Run button. Please use the config Run button to run the custom scene." % config.name)
 
+func _exit_tree():
+	_kill_pids()
+
+func _kill_pids():
+	for pid in pids:
+		OS.kill(pid)
+	pids = []
 
 ## API
 static func get_current_config() -> RunConfig:
@@ -43,6 +52,12 @@ static func get_current_config() -> RunConfig:
 
 	return configs[ind]
 
+static func get_config_from_name(name: StringName) -> RunConfig:
+	var configs := load_configs()
+	for c in configs:
+		if c.name == name:
+			return c
+	return null
 
 static func load_configs() -> Array[RunConfig]:
 	var settings = ProjectSettings.get_setting(_CONFIGS_PATH)

--- a/addons/run-configs/run-config-manager.gd
+++ b/addons/run-configs/run-config-manager.gd
@@ -24,6 +24,8 @@ func _init():
 	for key in env.keys():
 		OS.set_environment(key, env[key])
 
+	print(get_current_config_index())
+
 	print_rich("[color=gray][Run Config][/color] [color=white]Applied environment variables from the [b]%s[/b] config." % config.name)
 
 func _ready():

--- a/addons/run-configs/run-config-manager.gd
+++ b/addons/run-configs/run-config-manager.gd
@@ -8,8 +8,6 @@ const _CURRENT_CONFIG_PATH := CONFIGS_BASE_PATH + _CONFIGS_DATA_PATH + "/current
 
 const RunConfig := preload("res://addons/run-configs/models/run_config.gd")
 
-var pids = []
-
 func _init():
 	if not OS.has_feature(&"editor"):
 		return
@@ -33,14 +31,6 @@ func _ready():
 	if not config: return
 	if config.custom_scene != "" and get_tree().current_scene.scene_file_path != config.custom_scene:
 		print_rich("[color=gray][Run Config][/color] [color=yellow][Warn][/color] The [b]%s[/b] config has a custom scene set, but the game is ran from the regular Run button. Please use the config Run button to run the custom scene." % config.name)
-
-func _exit_tree():
-	_kill_pids()
-
-func _kill_pids():
-	for pid in pids:
-		OS.kill(pid)
-	pids = []
 
 ## API
 static func get_current_config() -> RunConfig:

--- a/addons/run-configs/run-configs
+++ b/addons/run-configs/run-configs
@@ -1,0 +1,1 @@
+../../godot-run-configs/addons/run-configs/

--- a/project.godot
+++ b/project.godot
@@ -12,12 +12,14 @@ config_version=5
 
 config/name="Run Configs Plugin"
 config/tags=PackedStringArray("addon")
+run/main_scene="res://scene_editor.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://icon.svg"
 
 [autoload]
 
 RunConfigManager="*res://addons/run-configs/run-config-manager.gd"
+Demo="*res://Demo.gd"
 
 [dotnet]
 
@@ -29,5 +31,5 @@ enabled=PackedStringArray("res://addons/run-configs/plugin.cfg")
 
 [run_configs]
 
-data/configs=["{\"custom_scene\":\"\",\"environment_variables\":{},\"name\":\"Default\",\"play_mode\":0}", "{\"custom_scene\":\"\",\"environment_variables\":{},\"name\":\"Debug\",\"play_mode\":0}", "{\"custom_scene\":\"\",\"environment_variables\":{},\"name\":\"Config (3)\",\"play_mode\":0}"]
-data/current=0
+data/configs=["{\"composite_configs\":[],\"custom_scene\":\"\",\"environment_variables\":{\"MY_VAR\":\"Main Scene\"},\"name\":\"Main Scene\",\"play_mode\":0}", "{\"composite_configs\":[],\"custom_scene\":\"res://scene_a.tscn\",\"environment_variables\":{\"MY_VAR\":\"A Scenes\"},\"name\":\"A Scene\",\"play_mode\":2}", "{\"composite_configs\":[],\"custom_scene\":\"res://scene_b.tscn\",\"environment_variables\":{\"MY_VAR\":\"B Scene\"},\"name\":\"B Scene\",\"play_mode\":2}", "{\"composite_configs\":[\"Main Scene\",\"A Scene\",\"B Scene\"],\"custom_scene\":\"\",\"environment_variables\":{\"MY_VAR\":\"Composite\"},\"name\":\"Composite\",\"play_mode\":3}"]
+data/current=3

--- a/scene_a.tscn
+++ b/scene_a.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://dlgb2ugbog56d"]
+
+[node name="Scene" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+theme_override_font_sizes/font_size = 46
+text = "This is Scene A"
+horizontal_alignment = 1
+
+[node name="Output" type="CodeEdit" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_font_sizes/font_size = 30
+editable = false

--- a/scene_b.tscn
+++ b/scene_b.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://dj5qco5kutgrc"]
+
+[node name="Scene" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+theme_override_font_sizes/font_size = 46
+text = "This is Scene B"
+horizontal_alignment = 1
+
+[node name="Output" type="CodeEdit" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_font_sizes/font_size = 30
+editable = false

--- a/scene_editor.tscn
+++ b/scene_editor.tscn
@@ -1,0 +1,19 @@
+[gd_scene format=3 uid="uid://t6yqfb3jaex6"]
+
+[node name="Scene" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+theme_override_font_sizes/font_size = 46
+text = "This is Scene Editor"
+horizontal_alignment = 1
+
+[node name="Output" type="CodeEdit" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+editable = false


### PR DESCRIPTION
Related to #8

Currently, environment variables aren't set properly. As I've ran out of ideas on how to make this, I submit the PR as a draft so we can better discuss how it could be done.

For now, the Composite config environment variables are applies to all instances. Ideally, each instance should have their own config's environment variables applies. This could be used for starting two instances of a game with one of them being the server via an env variable.

It is possible to set environment variables in `plugin.gd` before starting the process, but they have to be unset manually when the process is closed so it isn't ideal. Please tell me if you have a preferred way of handling this problem.

I added a demo project to test the composite config